### PR TITLE
Drop dependency + new argument for clicked handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,19 @@
 
 > Pulsante SSO per SPID in React
 
-[![NPM](https://img.shields.io/npm/v/@dej611/spid-react-button.svg)](https://www.npmjs.com/package/@dej611/spid-react-button) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
+[![NPM](https://img.shields.io/npm/v/@dej611/spid-react-button.svg)](https://www.npmjs.com/package/@dej611/spid-react-button)
 
 ## Install
 
 ```bash
-npm install --save @dej611/spid-react-button spid-smart-button
+npm install --save @dej611/spid-react-button typeface-titillium-web
 ```
 
-This package requires the `spid-smart-button` dependency for some assets.
+The package depends on the Titillium font.  
+An alternative to installing the local package is to use it via CDN, adding this line to your css file:
+```css
+@import url(https://fonts.googleapis.com/css?family=Titillium+Web:400,600,700,900);
+```
 
 ## Usage
 
@@ -19,11 +23,7 @@ import React, { Component } from 'react'
 
 import {SPIDReactButton} from '@dej611/spid-react-button'
 
-// For dropdown version
 import '@dej611/spid-react-button/dist/index.css'
-
-// For modal version
-import 'spid-smart-button/dist/spid-button.min.css';
 
 
 function Example(){
@@ -127,6 +127,7 @@ This is useful when a Service Provider identifies the IDP with a different strin
 
 **Type**: `(
 providerEntry : ProviderRecord,
+loginURL : string | undefined,
 event : React.MouseEvent<HTMLAnchorElement | MouseEvent> | React.MouseEvent<HTMLButtonElement | MouseEvent>) => void`  
 
 **Required**: No  

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useCallback } from 'react'
 
 import { SPIDReactButton, SPIDButtonProps, ProviderRecord } from '@dej611/spid-react-button'
-import 'spid-smart-button/dist/spid-button.min.css';
 import 'bootstrap-italia/dist/css/bootstrap-italia.min.css';
 import 'typeface-titillium-web';
 import 'typeface-roboto-mono';
@@ -48,9 +47,9 @@ const App = () => {
                   url={isValidURL ? buttonProps.url : defaultURL}
                   onProvidersShown={() => prependEvent({ type: buttonProps.type, name: 'onProvidersShown' })}
                   onProvidersHidden={() => prependEvent({ type: buttonProps.type, name: 'onProvidersHidden' })}
-                  onProviderClicked={(arg: ProviderRecord, e) => {
+                  onProviderClicked={(arg: ProviderRecord, url: string | undefined, e) => {
                     e.preventDefault();
-                    prependEvent({ type: buttonProps.type, name: 'onProvidersClicked', arg: JSON.stringify(arg, null, 2) })
+                    prependEvent({ type: buttonProps.type, name: 'onProvidersClicked', arg: JSON.stringify({url, arg}, null, 2) })
                   }}
                 />
                 <EventsTable events={events} />

--- a/example/src/CodeRenderer.tsx
+++ b/example/src/CodeRenderer.tsx
@@ -19,33 +19,29 @@ function isDefaultProp(prop: string, value: unknown){
     return initState[prop] === value;
 }
 
-const cssByType = {
-    'modal': `// requires the "spid-smart-button" dependency
-import 'spid-smart-button/dist/spid-button.min.css';`,
-    'dropdown': "import '@dej611/spid-react-button/dist/index.css';"
-};
-
 export const CodeRenderer = (buttonProps: NoFunctionProps) => {
     const entries = Object.entries(buttonProps);
-    const code = `import { SPIDReactButton } from '@dej611/spid-react-button'
-    ${cssByType[buttonProps.type]}
-    
-    function mySPIDButton(props){
-        return (
-            <SPIDReactButton 
-                ${entries
-                    .filter(([prop, value]) => !isDefaultProp(prop, value))
-                    .map(([prop, value]) => `${prop}={${JSON.stringify(value, null, 2)}}`)
-                    .join('\n            ')}
-            />
-        );
-    }`;
+    const code = `
+import { SPIDReactButton } from '@dej611/spid-react-button';
+import 'typeface-titillium-web';
+import '@dej611/spid-react-button/dist/index.css';
+
+function mySPIDButton(props){
+    return (
+        <SPIDReactButton 
+            ${entries
+                .filter(([prop, value]) => !isDefaultProp(prop, value))
+                .map(([prop, value]) => `${prop}={${JSON.stringify(value, null, 2)}}`)
+                .join('\n            ')}
+        />
+    );
+}`;
 
 return  <div><SyntaxHighlighter language="javascript" showLineNumbers
 
 wrapLines style={vs}>
     {code}
     </SyntaxHighlighter>
-    <CodeSandboxLink code={code} addDependency={buttonProps.type === 'modal'}/>
+    <CodeSandboxLink code={code}/>
     </div>
 }

--- a/example/src/Codesandbox.tsx
+++ b/example/src/Codesandbox.tsx
@@ -14,7 +14,7 @@ ReactDOM.render(
   rootElement
 );`
 
-function generateURLParams(code: string, addDependency: boolean){
+function generateURLParams(code: string){
   const manifest = {
     "name": "spid-react-button-example",
     "version": "1.0.0",
@@ -25,7 +25,8 @@ function generateURLParams(code: string, addDependency: boolean){
       "react": "17.0.2",
       "react-dom": "17.0.2",
       "react-scripts": "4.0.0",
-      "@dej611/spid-react-button": "latest"
+      "@dej611/spid-react-button": "latest",
+      "typeface-titillium-web": "latest"
     },
     "devDependencies": {
       "@babel/runtime": "7.13.8",
@@ -39,9 +40,6 @@ function generateURLParams(code: string, addDependency: boolean){
     },
     "browserslist": [">0.2%", "not dead", "not ie <= 11", "not op_mini all"]
   };
-  if(addDependency){
-    manifest.dependencies['spid-smart-button'] = 'latest';
-  }
     return getParameters({
     files: {
         // @ts-expect-error
@@ -60,6 +58,6 @@ function generateURLParams(code: string, addDependency: boolean){
   });
 }
 
-  export const CodeSandboxLink = ({code, addDependency}: {code: string, addDependency: boolean}) => {
-      return <a target="_blank noreferral" href={`https://codesandbox.io/api/v1/sandboxes/define?parameters=${generateURLParams(code, addDependency)}`} className="float-right"><Icon icon="it-software"/> Open it Codesandbox</a>
+  export const CodeSandboxLink = ({code}: {code: string}) => {
+      return <a target="_blank noreferral" href={`https://codesandbox.io/api/v1/sandboxes/define?parameters=${generateURLParams(code)}`} className="float-right"><Icon icon="it-software"/> Open it Codesandbox</a>
   }

--- a/example/src/Configurator.tsx
+++ b/example/src/Configurator.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { SPIDButtonProps} from '@dej611/spid-react-button'
+import { SPIDButtonProps } from '@dej611/spid-react-button'
 // @ts-expect-error
 import { Input, Col, Row, Toggle, FormGroup, Label } from 'design-react-kit';
 import { SelectComponent } from './BISelect';
@@ -22,7 +22,7 @@ type ConfiguratorProps = {
   isValidURL: boolean
 }
 
-export const Configurator = ({buttonProps, updateProp, setValidURL, isValidURL }: ConfiguratorProps) => {
+export const Configurator = ({ buttonProps, updateProp, setValidURL, isValidURL }: ConfiguratorProps) => {
 
 
   const { options: langOptions, selection: langSelection } = getOptionsAndCurrentSelection(['Italiano', 'English', 'Deutsche'], languages, buttonProps, 'lang')
@@ -33,150 +33,162 @@ export const Configurator = ({buttonProps, updateProp, setValidURL, isValidURL }
   const { options: methodOptions, selection: methodSelection } = getOptionsAndCurrentSelection(['GET', 'POST'], configurations, buttonProps, 'configuration')
   const { options: typeOptions, selection: typeSelection } = getOptionsAndCurrentSelection(['Modal', 'Dropown'], types, buttonProps, 'type')
 
-    const validProps = isValidURL ? {valid: true} : {invalid: true}
-    return <>
+  const validProps = isValidURL ? { valid: true } : { invalid: true }
+  return <>
     <div className="form-row">
-            <Col md={6}>
-              <Input
-                label={"URL - must contain '{{idp}}':"}
-                placeholder='Add a URL'
-                value={buttonProps.url}
-                {...validProps}
-                infoText={isValidURL ? '' : 'Please add the "{{idp}}" string in it'}
-                onChange={(event) => {
-                  // @ts-expect-error
-                  const newURL = event.target.value;
-                  setValidURL(newURL.indexOf('{{idp}}') > -1);
-                  updateProp('url', newURL);
-                }}
-              />
-            </Col>
-            <Col>
-              <FormGroup className="m-8">
-                <SelectComponent
-                  label='Method:'
-                  selectedValue={methodSelection}
-                  options={methodOptions}
-                  onChange={(selectedOption) => {
-                    if (selectedOption != null && configurations.includes(selectedOption.value)) {
-                      updateProp('configuration', selectedOption.value)
-                    }
-                  }}
-                />
-                </FormGroup>
-            </Col>
+      <Col md={6}>
+        <Input
+          label={"URL - must contain '{{idp}}':"}
+          placeholder='Add a URL'
+          value={buttonProps.url}
+          {...validProps}
+          infoText={isValidURL ? '' : 'Please add the "{{idp}}" string in it'}
+          onChange={(event) => {
+            // @ts-expect-error
+            const newURL = event.target.value;
+            setValidURL(newURL.indexOf('{{idp}}') > -1);
+            updateProp('url', newURL);
+          }}
+        />
+      </Col>
+      <Col>
+        <FormGroup className="m-8">
+          <SelectComponent
+            label='Method:'
+            selectedValue={methodSelection}
+            options={methodOptions}
+            onChange={(selectedOption) => {
+              if (selectedOption != null && configurations.includes(selectedOption.value)) {
+                updateProp('configuration', selectedOption.value)
+              }
+            }}
+          />
+        </FormGroup>
+      </Col>
+    </div>
+    <div className="form-row">
+      <Col md={6}>
+        <FormGroup className="m-8">
+          <SelectComponent
+            label='Language:'
+            selectedValue={langSelection}
+            options={langOptions}
+            onChange={(selectedOption) => {
+              if (selectedOption != null && languages.includes(selectedOption.value)) {
+                updateProp('lang', selectedOption.value)
+              }
+            }}
+          />
+        </FormGroup>
+      </Col>
+      <Col md={6}>
+        <FormGroup className="m-8">
+          <SelectComponent
+            label='Size:'
+            selectedValue={sizeSelection}
+            options={sizeOptions}
+            onChange={(selectedOption) => {
+              if (selectedOption != null && sizes.includes(selectedOption.value)) {
+                updateProp('size', selectedOption.value)
+              }
+            }}
+          />
+        </FormGroup>
+      </Col>
+    </div>
+    <div className="form-row">
+      <Col md={6}>
+        <FormGroup className="m-8">
+          <SelectComponent
+            label='Theme:'
+            selectedValue={colorThemeSelection}
+            options={colorSchemeOptions}
+            onChange={(selectedOption) => {
+              if (selectedOption != null && colorThemes.includes(selectedOption.value)) {
+                updateProp('theme', selectedOption.value)
+              }
+            }}
+          />
+        </FormGroup>
+      </Col>
+      <Col md={6}>
+        <FormGroup className="m-8">
+          <SelectComponent
+            label='Corners style:'
+            selectedValue={cornerTypeSelection}
+            options={cornerTypeOptions}
+            onChange={(selectedOption) => {
+              if (selectedOption != null && cornerTypes.includes(selectedOption.value)) {
+                updateProp('corners', selectedOption.value)
+              }
+            }}
+          />
+        </FormGroup>
+      </Col>
+    </div>
+    <div className="form-row">
+      <Col>
+        <FormGroup check>
+          <Toggle
+            label='Fluid'
+            checked={buttonProps.fluid}
+            onChange={({ target }) => {
+              // @ts-expect-error
+              updateProp('fluid', target.checked)
+            }}
+          />
+        </FormGroup>
+      </Col>
+      <Col md={4}>
+        <FormGroup className="m-8">
+        <SelectComponent
+          label='Type'
+          selectedValue={typeSelection}
+          options={typeOptions}
+          onChange={(selectedOption) => {
+            if (selectedOption != null && types.includes(selectedOption.value)) {
+              updateProp('type', selectedOption.value)
+            }
+          }}
+        />
+        </FormGroup>
+      </Col>
+      <Col md={4}>
+        <FormGroup className="m-8">
+        <SelectComponent
+          label='Protocol'
+          selectedValue={protocolSelection}
+          options={protocolOptions}
+          onChange={(selectedOption) => {
+            if (selectedOption != null && protocols.includes(selectedOption.value)) {
+              updateProp('protocol', selectedOption.value)
+            }
+          }}
+        />
+        </FormGroup>
+      </Col>
+    </div>
+    <Row>
+      <fieldset>
+        <legend>Provider supported:</legend>
+        <FormGroup check>
+          {providersList.map(({ entityID, entityName, logo }) => <div key={entityName}>
+            <Input id={entityName} type="checkbox" checked={buttonProps.supported.includes(entityID)} onChange={(event) => {
+              // @ts-expect-error
+              const isChecked = event.target.checked;
+              if (isChecked) {
+                updateProp('supported', [...buttonProps.supported, entityID])
+              } else {
+                updateProp('supported', buttonProps.supported.filter((id) => entityID !== id))
+              }
+            }} />
+            <Label htmlFor={entityName} check>
+              <img src={logo} alt={entityName} height={20} />
+            </Label>
           </div>
-          <div className="form-row">
-            <Col md={6}>
-              <FormGroup className="m-8">
-                <SelectComponent
-                  label='Language:'
-                  selectedValue={langSelection}
-                  options={langOptions}
-                  onChange={(selectedOption) => {
-                    if (selectedOption != null && languages.includes(selectedOption.value)) {
-                      updateProp('lang', selectedOption.value)
-                    }
-                  }}
-                />
-                </FormGroup>
-            </Col>
-            <Col md={6}>
-              <FormGroup className="m-8">
-                <SelectComponent
-                  label='Size:'
-                  selectedValue={sizeSelection}
-                  options={sizeOptions}
-                  onChange={(selectedOption) => {
-                    if (selectedOption != null && sizes.includes(selectedOption.value)) {
-                      updateProp('size', selectedOption.value)
-                    }
-                  }}
-                /></FormGroup></Col>
-          </div>
-          <div className="form-row"><Col md={6}>
-            <FormGroup className="m-8">
-              <SelectComponent
-                label='Theme:'
-                selectedValue={colorThemeSelection}
-                options={colorSchemeOptions}
-                onChange={(selectedOption) => {
-                  if (selectedOption != null && colorThemes.includes(selectedOption.value)) {
-                    updateProp('theme', selectedOption.value)
-                  }
-                }}
-              /></FormGroup></Col><Col md={6}>
-              <FormGroup className="m-8">
-                <SelectComponent
-                  label='Corners style:'
-                  selectedValue={cornerTypeSelection}
-                  options={cornerTypeOptions}
-                  onChange={(selectedOption) => {
-                    if (selectedOption != null && cornerTypes.includes(selectedOption.value)) {
-                      updateProp('corners', selectedOption.value)
-                    }
-                  }}
-                /></FormGroup></Col>
-          </div>
-          <div className="form-row">
-            <Col>
-              <FormGroup check >
-                <Toggle
-                  label='Fluid'
-                  checked={buttonProps.fluid}
-                  onChange={({ target }) => {
-                    // @ts-expect-error
-                    updateProp('fluid', target.checked)
-                  }}
-                />
-              </FormGroup>
-            </Col>
-            <Col md={4}>
-              <SelectComponent
-                label='Type'
-                selectedValue={typeSelection}
-                options={typeOptions}
-                onChange={(selectedOption) => {
-                  if (selectedOption != null && types.includes(selectedOption.value)) {
-                    updateProp('type', selectedOption.value)
-                  }
-                }}
-              />
-              </Col>
-            <Col md={4}>
-              <SelectComponent
-                label='Protocol'
-                selectedValue={protocolSelection}
-                options={protocolOptions}
-                onChange={(selectedOption) => {
-                  if (selectedOption != null && protocols.includes(selectedOption.value)) {
-                    updateProp('protocol', selectedOption.value)
-                  }
-                }}
-              />
-              </Col>
-          </div>
-          <Row>
-            <fieldset>
-              <legend>Provider supported:</legend>
-              <FormGroup check>
-                {providersList.map(({ entityID, entityName, logo }) => <div key={entityName}>
-                  <Input id={entityName} type="checkbox" checked={buttonProps.supported.includes(entityID)} onChange={(event) => {
-                    // @ts-expect-error
-                    const isChecked = event.target.checked;
-                    if (isChecked) {
-                      updateProp('supported', [...buttonProps.supported, entityID])
-                    } else {
-                      updateProp('supported', buttonProps.supported.filter((id) => entityID !== id))
-                    }
-                  }} />
-                  <Label htmlFor={entityName} check>
-                    <img src={logo} alt={entityName} height={20} />
-                  </Label>
-                </div>
-                )}
-              </FormGroup>
-            </fieldset>
-          </Row>
-        </>
+          )}
+        </FormGroup>
+      </fieldset>
+    </Row>
+  </>
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17602,6 +17602,12 @@
       "integrity": "sha512-Jd5fYTiqzinZdoIY382W7tQXTwAzWRdg8KbHfaxmb78m1/3jL9riXtk23oBOKwhi8GFVykCOdPzEJKY87/D0LQ==",
       "dev": true
     },
+    "typeface-titillium-web": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/typeface-titillium-web/-/typeface-titillium-web-1.1.13.tgz",
+      "integrity": "sha512-R21mXf9hoqle+dgR7k6C6QUN2XElopQNsTDYI5DoU1buuYayVvzn2jd2ihKJTwM/hJsltLrlJUkyumc3FFgevA==",
+      "dev": true
+    },
     "typescript": {
       "version": "3.9.9",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "build:ts": "microbundle-crl --no-compress --format modern,cjs",
     "build:svg": "./scripts/svgs.sh",
-    "build": "npm run build:svg && npm run build:ts && npm run doc",
+    "build:css": "./scripts/styles.sh",
+    "build": "npm run build:css && npm run build:svg && npm run build:ts && npm run doc",
     "start": "microbundle-crl watch --no-compress --format modern,cjs",
     "prepare": "run-s build",
     "test": "run-s test:unit test:lint test:build",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "react": "^16.0.0",
-    "spid-smart-button": "1.1.5"
+    "typeface-titillium-web": "latest"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "5.11.9",
@@ -66,7 +66,8 @@
     "spid-smart-button": "1.1.5",
     "svgo": "^2.2.2",
     "typedoc": "^0.20.34",
-    "typescript": "3.9.9"
+    "typescript": "3.9.9",
+    "typeface-titillium-web": "latest"
   },
   "files": [
     "dist"

--- a/scripts/readme.template
+++ b/scripts/readme.template
@@ -20,7 +20,8 @@ An alternative to installing the local package is to use it via CDN, adding this
 
 ```jsx
 import React, { Component } from 'react'
-
+// Import it via package or in your CSS file via the CDN @import
+import 'typeface-titillium-web';
 import {SPIDReactButton} from '@dej611/spid-react-button'
 
 import '@dej611/spid-react-button/dist/index.css'

--- a/scripts/readme.template
+++ b/scripts/readme.template
@@ -2,15 +2,19 @@
 
 > Pulsante SSO per SPID in React
 
-[![NPM](https://img.shields.io/npm/v/@dej611/spid-react-button.svg)](https://www.npmjs.com/package/@dej611/spid-react-button) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
+[![NPM](https://img.shields.io/npm/v/@dej611/spid-react-button.svg)](https://www.npmjs.com/package/@dej611/spid-react-button)
 
 ## Install
 
 ```bash
-npm install --save @dej611/spid-react-button spid-smart-button
+npm install --save @dej611/spid-react-button typeface-titillium-web
 ```
 
-This package requires the `spid-smart-button` dependency for some assets.
+The package depends on the Titillium font.  
+An alternative to installing the local package is to use it via CDN, adding this line to your css file:
+```css
+@import url(https://fonts.googleapis.com/css?family=Titillium+Web:400,600,700,900);
+```
 
 ## Usage
 
@@ -19,11 +23,7 @@ import React, { Component } from 'react'
 
 import {SPIDReactButton} from '@dej611/spid-react-button'
 
-// For dropdown version
 import '@dej611/spid-react-button/dist/index.css'
-
-// For modal version
-import 'spid-smart-button/dist/spid-button.min.css';
 
 
 function Example(){

--- a/scripts/styles.sh
+++ b/scripts/styles.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 cp ./node_modules/spid-smart-button/dist/spid-button.min.css ./src/modalVariant/index.module.css
-if [ uname = 'Linux' ]; then
+if [ $(uname) = 'Linux' ]; then
     sed -i '/@import url/d' ./src/modalVariant/index.module.css
 else 
     sed -i '' '/@import url/d' ./src/modalVariant/index.module.css

--- a/scripts/styles.sh
+++ b/scripts/styles.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+cp ./node_modules/spid-smart-button/dist/spid-button.min.css ./src/modalVariant/index.module.css
+if [ uname = 'Linux' ]; then
+    sed -i '/@import url/d' ./src/modalVariant/index.module.css
+else 
+    sed -i '' '/@import url/d' ./src/modalVariant/index.module.css
+fi

--- a/src/component.test.tsx
+++ b/src/component.test.tsx
@@ -254,7 +254,43 @@ for (const type of types) {
           expect(onClickCallback).toHaveBeenCalledTimes(1);
           expect(onClickCallback).toHaveBeenCalledWith(
             provider,
-            // React native event
+            expect.stringContaining('/myLogin/idp'),
+            // React mouse event
+            expect.anything()
+          );
+        });
+
+        it('should have the custom id for each clicked IDP', () => {
+          const onClickCallback = jest.fn();
+          const customMapping = providers.reduce((memo, { entityID }, i) => {
+            memo[entityID] = i;
+            return memo;
+          }, {});
+          render(
+            <SPIDReactButton
+              url={defaultURL}
+              configuration={configuration}
+              type={type}
+              onProviderClicked={onClickCallback}
+              mapping={customMapping}
+            />
+          );
+          helper.openList();
+
+          const [firstProviderAvailable] = helper.getEnabledProviders();
+
+          helper.clickProvider(firstProviderAvailable);
+
+          helper.closeList();
+          const indexID = firstProviderAvailable.id?.trim();
+          const provider = providers[indexID]!;
+
+          console.log({ indexID, provider });
+          expect(onClickCallback).toHaveBeenCalledWith(
+            provider,
+            '/myLogin/idp=' +
+              encodeURIComponent(customMapping[provider.entityID]),
+            // React mouse event
             expect.anything()
           );
         });

--- a/src/dropdownVariant/ProvidersMenu.tsx
+++ b/src/dropdownVariant/ProvidersMenu.tsx
@@ -105,15 +105,17 @@ const ProviderButton = ({
   const linkTitle = isActive
     ? i18n('accedi_con_idp', idp.entityName)
     : i18n('idp_disabled');
+
+  const loginURL = isActive ? actionURL : undefined;
   if (isGetMethod(configuration)) {
     return (
       <a
         title={linkTitle}
-        href={isActive ? actionURL : undefined}
+        href={loginURL}
         // @ts-expect-error
         disabled={!isActive}
         className={`${styles.idpLogo} ${isActive ? '' : styles.disabled}`}
-        onClick={(e) => onProviderClicked?.(idp, e)}
+        onClick={(e) => onProviderClicked?.(idp, loginURL, e)}
         role='link'
         id={entityID}
       >
@@ -126,11 +128,16 @@ const ProviderButton = ({
     <form name='spid_idp_access' action={actionURL} method='POST'>
       <button
         className={`${styles.idpLogo} ${isActive ? '' : styles.disabled}`}
-        id={idp.entityID}
+        id={entityID}
         name={linkTitle}
         title={linkTitle}
         type='submit'
-        onClick={(e) => onProviderClicked?.(idp, e)}
+        onClick={(e) => {
+          if (!isActive) {
+            e.preventDefault();
+          }
+          return onProviderClicked?.(idp, loginURL, e);
+        }}
       >
         <ProviderButtonContent idp={idp} title={linkTitle} />
       </button>

--- a/src/modalVariant/ProviderButton.tsx
+++ b/src/modalVariant/ProviderButton.tsx
@@ -13,6 +13,8 @@ import type {
   SPIDButtonProps
 } from '../shared/types';
 
+import styles from './index.module.css';
+
 const ProviderButtonContent = ({
   entityName,
   logo
@@ -63,17 +65,21 @@ export const ProviderButton = ({
         }
       : { classNames: emptyClass }
     : { classNames: emptyClass };
+  const loginURL = isActive ? actionURL : undefined;
 
   if (isGetMethod(configuration)) {
     return (
-      <span className={`spid-button-idp ${classNames}`} style={style}>
+      <span
+        className={`${styles['spid-button-idp']} ${styles[classNames] ?? ''}`}
+        style={style}
+      >
         <a
           id={entityID}
           title={linkTitle}
-          href={isActive ? actionURL : undefined}
+          href={loginURL}
           // @ts-expect-error
           disabled={!isActive}
-          onClick={(e) => onProviderClicked?.(idp, e)}
+          onClick={(e) => onProviderClicked?.(idp, loginURL, e)}
           role='link'
         >
           <ProviderButtonContent entityName={idp.entityName} logo={idp.logo} />
@@ -83,15 +89,20 @@ export const ProviderButton = ({
   }
   const { fieldName, extraFields = {} } = configuration;
   return (
-    <span className='spid-button-idp'>
+    <span className={styles['spid-button-idp']}>
       <form action={actionURL} method='POST'>
         <button
           id={entityID}
           type='submit'
-          className='spid-button-idp-button'
+          className={styles['spid-button-idp-button']}
           title={linkTitle}
           disabled={!isActive}
-          onClick={(e) => onProviderClicked?.(idp, e)}
+          onClick={(e) => {
+            if (!isActive) {
+              e.preventDefault();
+            }
+            return onProviderClicked?.(idp, loginURL, e);
+          }}
         >
           <ProviderButtonContent entityName={idp.entityName} logo={idp.logo} />
         </button>

--- a/src/modalVariant/ProvidersModal.tsx
+++ b/src/modalVariant/ProvidersModal.tsx
@@ -12,8 +12,6 @@ import {
   BUTTON_DELAY_TIME,
   DELAY_STEP,
   emptyClass,
-  fadeInClass,
-  fadeOutClass,
   logoAnimationOutClass,
   panelAnimClass,
   possibleStates
@@ -24,12 +22,14 @@ import { isVisible } from './utils';
 import { ProviderButton } from './ProviderButton';
 import { TranslateFn } from '../shared/i18n';
 
+import styles from './index.module.css';
+
 const ButtonImage = ({ url, altText }: { url: string; altText: string }) => (
   <img aria-hidden='true' src={url} alt={altText} style={{ float: 'left' }} />
 );
 
 function getModalClasses({ type }: ModalState) {
-  const fadeInLeftClass = `${fadeInClass}-left`;
+  const fadeInLeftClass = `spid-button-fade-in-left`;
   switch (type) {
     case possibleStates.ENTERING.type:
       return {
@@ -96,27 +96,38 @@ export const ProvidersModal = ({
   } = getModalClasses(visibility);
 
   return (
-    <section className='spid-enter-container' hidden={!isVisible(visibility)}>
-      <div className='spid-enter'>
+    <section
+      className={styles['spid-enter-container']}
+      hidden={!isVisible(visibility)}
+    >
+      <div className={styles['spid-enter']}>
         <section
-          className={`spid-button-panel spid-button-panel-select ${panelClasses}`}
+          className={`${styles['spid-button-panel']} ${
+            styles['spid-button-panel-select'] ?? ''
+          } ${styles[panelClasses] ?? ''}`}
           aria-label={i18n('scegli_provider_SPID')}
           tabIndex={0}
         >
-          <header className='spid-button-header'>
-            <div className='spid-button-panel-back'>
-              <div className={`spid-button-logo ${buttonLogoClasses}`}>
+          <header className={styles['spid-button-header']}>
+            <div className={styles['spid-button-panel-back']}>
+              <div
+                className={`${styles['spid-button-logo']} ${
+                  styles[buttonLogoClasses] ?? ''
+                }`}
+              >
                 <ButtonImage
                   url={SpidLogoUrl}
                   altText={i18n('alt_logo_SPID')}
                 />
               </div>
               <div
-                className={`spid-button-close-button ${fadeOutClass}-right ${buttonCloseClasses}`}
+                className={`${styles['spid-button-close-button']} ${
+                  styles['spid-button-fade-out-right']
+                } ${styles[buttonCloseClasses] ?? ''}`}
               >
                 <button
                   tabIndex={0}
-                  className='spid-button-panel-close-button spid-button-navigable'
+                  className={`${styles['spid-button-panel-close-button']} ${styles['spid-button-navigable']}`}
                   aria-label={i18n('naviga_indietro')}
                   onClick={closeModal}
                 >
@@ -128,19 +139,21 @@ export const ProvidersModal = ({
               </div>
             </div>
           </header>
-          <div className='spid-button-panel-content'>
+          <div className={styles['spid-button-panel-content']}>
             <img
-              className={`spid-button-little-man-icon ${buttonManIconClasses}`}
+              className={`${styles['spid-button-little-man-icon']} ${
+                styles[buttonManIconClasses] ?? ''
+              }`}
               src={SpidLogoAnimationBlackUrl}
               alt={i18n('entra_con_SPID')}
             />
-            <div className='spid-button-panel-content-center'>
+            <div className={styles['spid-button-panel-content-center']}>
               <h1
-                className={`spid-enter-title-page ${fadeInClass}-bottom ${fadeOutClass}-bottom`}
+                className={`${styles['spid-enter-title-page']} ${styles['spid-button-fade-in-bottom']} ${styles['spid-button-fade-out-bottom']}`}
               >
                 {i18n('scegli_provider_SPID')}
               </h1>
-              <div className='spid-idp-list'>
+              <div className={styles['spid-idp-list']}>
                 {providers.map((idp, i) => {
                   const isActive = isProviderActive(
                     idp,
@@ -168,7 +181,7 @@ export const ProvidersModal = ({
                   );
                 })}
               </div>
-              <div className='spid-non-hai-spid'>
+              <div className={styles['spid-non-hai-spid']}>
                 {i18n('non_hai_SPID')}{' '}
                 <a
                   href='https://www.spid.gov.it/richiedi-spid'
@@ -178,9 +191,9 @@ export const ProvidersModal = ({
                 </a>
               </div>
             </div>
-            <div className='spid-foot-btn'>
+            <div className={styles['spid-foot-btn']}>
               <button
-                className='spid-cancel-access-button'
+                className={styles['spid-cancel-access-button']}
                 onClick={closeModal}
               >
                 {i18n('annulla_accesso')}

--- a/src/modalVariant/constants.tsx
+++ b/src/modalVariant/constants.tsx
@@ -13,8 +13,6 @@ export const possibleStates = {
 } as const;
 
 export const panelAnimClass = 'spid-button-panel-anim';
-export const fadeInClass = 'spid-button-fade-in';
-export const fadeOutClass = 'spid-button-fade-out';
 export const logoAnimationOutClass = 'spid-button-logo-animation-out';
 export const emptyClass = '';
 export const buttonIconAnimationClass = 'spid-button-icon-animation';

--- a/src/modalVariant/index.module.css
+++ b/src/modalVariant/index.module.css
@@ -1,0 +1,1034 @@
+@charset "UTF-8";
+/*
+    Created on : 7-ott-2017, 13.08.21
+    Author     : Simone Rescio
+*/
+/*
+ * Indirizzo di produzione degli assets, inserire indirizzo reale
+ */
+.spid-enter-container {
+  min-width: 300px; }
+  .spid-enter-container a {
+    cursor: pointer;
+    color: #06c !important; }
+  .spid-enter-container h1 {
+    color: #17324d;
+    font-size: 2rem;
+    font-family: "Titillium Web", HelveticaNeue-Light, "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif; }
+
+.spid-idp-list {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+      -ms-flex-flow: row wrap;
+          flex-flow: row wrap; }
+  .spid-idp-list .spid-button-idp {
+    margin: 12px auto;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+            flex-direction: column;
+    width: 40%;
+    background: #f5f6f7;
+    border-radius: 3px; }
+    .spid-idp-list .spid-button-idp img {
+      max-height: 30px;
+      height: 100%;
+      width: auto; }
+    .spid-idp-list .spid-button-idp span {
+      padding-top: 5px;
+      font-family: "Titillium Web", HelveticaNeue-Light, "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+      font-size: 1.2em;
+      font-weight: bold; }
+    .spid-idp-list .spid-button-idp form {
+      height: 100%;
+      padding: 10px; }
+      .spid-idp-list .spid-button-idp form:active {
+        border: 3px solid #f7910d; }
+      .spid-idp-list .spid-button-idp form .spid-button-idp-button {
+        border: 0;
+        width: 100%;
+        cursor: pointer;
+        background: #f5f6f7;
+        padding: 5px;
+        height: 100%; }
+        .spid-idp-list .spid-button-idp form .spid-button-idp-button[disabled] {
+          opacity: 0.2;
+          cursor: not-allowed; }
+    .spid-idp-list .spid-button-idp a {
+      height: 100%;
+      border: 3px solid white;
+      padding: 10px;
+      text-decoration: none; }
+      .spid-idp-list .spid-button-idp a:active {
+        border: 3px solid #f7910d; }
+      .spid-idp-list .spid-button-idp a[disabled] {
+        opacity: 0.2;
+        cursor: not-allowed;
+        pointer-events: none; }
+
+.spid-button-logo {
+  float: left;
+  width: 50%; }
+
+.spid-button-close-button {
+  float: right;
+  margin-top: 5px; }
+
+.spid-button,
+.spid-cancel-access-button {
+  font-family: "Titillium Web", HelveticaNeue-Light, "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif; }
+
+.spid-button-navigable {
+  background: transparent !important;
+  cursor: pointer;
+  font-size: 1em; }
+
+.spid-enter-container {
+  position: fixed;
+  z-index: 999;
+  top: 0;
+  left: 0; }
+
+.spid-non-hai-spid {
+  margin-top: 10px;
+  margin-bottom: 10px;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  text-align: center;
+  font-size: 15px;
+  font-family: "Titillium Web", HelveticaNeue-Light, "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif; }
+  .spid-non-hai-spid a {
+    font-weight: bold; }
+
+.spid-enter {
+  height: 0; }
+
+.spid-button-panel {
+  top: 0;
+  left: 0;
+  margin-left: 0%;
+  margin-top: 0%;
+  margin-right: 0%;
+  width: 100vw;
+  height: 100vh;
+  color: #000;
+  position: fixed;
+  z-index: 1;
+  overflow: auto;
+  background: white; }
+
+.spid-button-header {
+  background-color: #fff;
+  color: #fff;
+  display: block;
+  overflow: hidden;
+  position: static;
+  min-width: 300px;
+  padding: 40px; }
+  .spid-button-header .spid-button-logo {
+    float: left;
+    width: 33.33333vw;
+    font-size: 30px; }
+  .spid-button-header .spid-button-panel-back {
+    min-width: 32px; }
+    .spid-button-header .spid-button-panel-back a,
+    .spid-button-header .spid-button-panel-back button,
+    .spid-button-header .spid-button-panel-back button a {
+      float: left;
+      width: auto;
+      border: none;
+      outline: none;
+      display: block;
+      cursor: pointer; }
+    .spid-button-header .spid-button-panel-back button:hover,
+    .spid-button-header .spid-button-panel-back button:focus,
+    .spid-button-header .spid-button-panel-back a:hover,
+    .spid-button-header .spid-button-panel-back a:focus {
+      opacity: 0.5; }
+    .spid-button-header .spid-button-panel-back img {
+      max-height: 50px; }
+  .spid-button-header .spid-button-logo img {
+    max-height: 37px; }
+
+.spid-button-panel-content {
+  position: relative;
+  display: block;
+  min-width: 300px;
+  margin-bottom: 10px; }
+  .spid-button-panel-content .spid-enter-title-page {
+    background: transparent;
+    display: block;
+    text-align: center; }
+
+.spid-button-panel-content-center {
+  text-align: center;
+  margin: auto;
+  overflow: auto;
+  height: 100%;
+  margin-bottom: 60px;
+  max-width: 500px; }
+
+.spid-button-icon {
+  border: none;
+  padding-right: 8px;
+  vertical-align: middle;
+  display: inline-block; }
+  .spid-button-icon svg {
+    fill: #fff; }
+
+.spid-button-little-man-icon {
+  width: 32px;
+  opacity: 0;
+  position: absolute; }
+
+@media screen and (max-width: 767px) {
+  .spid-button-little-man-icon {
+    display: none; } }
+
+.spid-button-text {
+  vertical-align: top; }
+
+.spid-button-size-small {
+  font-size: 14px;
+  height: 40px;
+  padding: 10px 20px; }
+  .spid-button-size-small > span img {
+    width: 16px;
+    height: 16px;
+    border: 0; }
+
+.spid-button-size-medium {
+  font-size: 16px;
+  height: 48px;
+  padding: 12px 24px; }
+  .spid-button-size-medium > span img {
+    width: 24px;
+    height: 24px;
+    border: 0; }
+
+.spid-button-size-large {
+  font-size: 18px;
+  height: 56px;
+  padding: 12px 28px; }
+  .spid-button-size-large > span img {
+    width: 32px;
+    height: 32px;
+    border: 0; }
+
+.spid-button-fluid {
+  width: 100%;
+  max-width: 400px; }
+
+.spid-cancel-access-button {
+  background-color: #fcfdff !important;
+  padding: 12px 24px;
+  color: #50565c !important;
+  font-family: "Titillium Web", HelveticaNeue-Light, "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+  font-weight: 600;
+  font-size: 16px;
+  display: inline-block;
+  -webkit-box-shadow: inset 0 0 0 1px #e6e9f2;
+          box-shadow: inset 0 0 0 1px #e6e9f2;
+  border-radius: 4px;
+  border: 0 solid transparent;
+  height: 55px;
+  margin: auto;
+  width: 90%;
+  text-align: center;
+  line-height: 1.5;
+  vertical-align: middle;
+  cursor: pointer; }
+  .spid-cancel-access-button:active:focus {
+    -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125), 0 0 0 0.2rem rgba(92, 111, 130, 0.5);
+            box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125), 0 0 0 0.2rem rgba(92, 111, 130, 0.5); }
+  .spid-cancel-access-button:active {
+    color: #5c6f82; }
+  .spid-cancel-access-button:hover {
+    color: #50565c;
+    -webkit-box-shadow: inset 0 0 0 1px #c9cedc;
+    box-shadow: inset 0 0 0 1px #c9cedc; }
+
+.spid-button-col {
+  float: left;
+  width: 100vw;
+  width: 24.99999%; }
+  .spid-button-col.xs12 {
+    width: 49.99999%; }
+
+#spid-enter-title-container {
+  padding-top: 1.25em; }
+
+#spid-button-action-button-container {
+  width: 100%; }
+  #spid-button-action-button-container button {
+    border: none; }
+
+.spid-button-action-button {
+  width: 49.99999%;
+  height: 65px;
+  color: #0073e6;
+  font-weight: 700;
+  background-color: #fff;
+  display: block;
+  float: left; }
+  .spid-button-action-button span {
+    position: relative;
+    top: -4px; }
+
+.spid-button-visibile {
+  display: block !important;
+  opacity: 0; }
+
+.spid-button-positive {
+  color: #fff;
+  background-color: #0073e6; }
+  .spid-button-positive:hover, .spid-button-positive:focus, .spid-button-positive:active {
+    background-color: #0059b3;
+    color: #fff; }
+  .spid-button-positive:visited {
+    background-color: #0073e6;
+    color: #fff; }
+  .spid-button-positive svg {
+    fill: #fff; }
+
+.spid-button-negative {
+  color: #0073e6;
+  background-color: #fff; }
+  .spid-button-negative:hover, .spid-button-negative:focus, .spid-button-negative:active {
+    background-color: #fff;
+    color: #0059b3; }
+  .spid-button-negative:visited {
+    background-color: #fff;
+    color: #0073e6; }
+
+.spid-button-rounded {
+  border-radius: 4px;
+  margin: 16px; }
+
+.spid-button-sharp {
+  border-radius: 0; }
+
+/*
+ * Deve essere l'ultimo set di regole, così che dopo che i pulsanti sono stati renderizzati con invisibilità inline
+ * si da tempo al browser di caricare e parsare i fogli di stile appena iniettati, di google font e del presente
+ * così da evitare di vedere prima i pulsanti "rotti" che poi si aggiustano gradualmente mentre il CSS viene scaricato e parsato
+ * in questo modo i pulsanti appaiono pochi istanti dopo correttamente stilizzati, sovrascrivendo l'attributo hidden
+ */
+.spid-button {
+  position: relative;
+  border: 0;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600; }
+  .spid-button .spid-button-logo {
+    position: absolute;
+    display: block;
+    margin: auto;
+    width: 12%;
+    top: 30%;
+    left: 14%; }
+
+.spid-foot-btn {
+  text-align: center;
+  max-width: 500px;
+  bottom: 0;
+  background-color: white;
+  margin: -40px auto auto auto;
+  width: 100%;
+  padding-bottom: 4%;
+  position: relative; }
+  .spid-foot-btn::after {
+    content: "";
+    position: absolute;
+    z-index: -1;
+    -webkit-box-shadow: 0 0 2rem rgba(0, 0, 0, 0.15);
+    box-shadow: 0 0 2rem rgba(0, 0, 0, 0.15);
+    left: 10%;
+    right: 10%;
+    width: 80%;
+    height: 50%;
+    border-radius: 100%; }
+
+@media screen and (max-width: 767px) {
+  .spid-foot-btn {
+    position: fixed;
+    left: 50%;
+    -webkit-transform: translateX(-50%);
+        -ms-transform: translateX(-50%);
+            transform: translateX(-50%); } }
+
+.spid-button-panel-anim {
+  -webkit-animation-delay: 0s;
+          animation-delay: 0s;
+  -webkit-animation-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
+          animation-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
+  -webkit-animation-iteration-count: 1;
+          animation-iteration-count: 1;
+  -webkit-animation-direction: normal;
+          animation-direction: normal;
+  -webkit-animation-fill-mode: forwards;
+          animation-fill-mode: forwards; }
+
+.spid-enter-container {
+  display: block;
+  -webkit-transition-duration: 1s;
+       -o-transition-duration: 1s;
+          transition-duration: 1s;
+  -webkit-transition-delay: 0.5s;
+       -o-transition-delay: 0.5s;
+          transition-delay: 0.5s;
+  -webkit-transition-property: visibility;
+  -o-transition-property: visibility;
+  transition-property: visibility; }
+  .spid-enter-container[hidden] {
+    visibility: hidden;
+    -webkit-transition-duration: 0s;
+         -o-transition-duration: 0s;
+            transition-duration: 0s;
+    -webkit-transition-property: visibility;
+    -o-transition-property: visibility;
+    transition-property: visibility;
+    -webkit-transition-delay: 1s;
+         -o-transition-delay: 1s;
+            transition-delay: 1s;
+    pointer-events: none; }
+    .spid-enter-container[hidden] .spid-button-panel-anim {
+      -webkit-animation-name: anim-panel-out;
+              animation-name: anim-panel-out;
+      -webkit-animation-duration: 1s;
+              animation-duration: 1s; }
+      .spid-enter-container[hidden] .spid-button-panel-anim .spid-button-fade-out-left {
+        -webkit-animation-name: spid-button-logo-left-fade-out;
+                animation-name: spid-button-logo-left-fade-out;
+        -webkit-animation-duration: 0.5s;
+                animation-duration: 0.5s;
+        -webkit-animation-fill-mode: both;
+                animation-fill-mode: both; }
+      .spid-enter-container[hidden] .spid-button-panel-anim .spid-button-fade-out-right {
+        -webkit-animation-name: spid-button-close-right-fade-out;
+                animation-name: spid-button-close-right-fade-out;
+        -webkit-animation-duration: 0.5s;
+                animation-duration: 0.5s;
+        -webkit-animation-fill-mode: both;
+                animation-fill-mode: both; }
+      .spid-enter-container[hidden] .spid-button-panel-anim .spid-button-fade-out-bottom {
+        -webkit-animation-name: spid-button-title-fade-out;
+                animation-name: spid-button-title-fade-out;
+        -webkit-animation-duration: 0.5s;
+                animation-duration: 0.5s;
+        -webkit-animation-fill-mode: both;
+                animation-fill-mode: both; }
+  .spid-enter-container:not([hidden]) .spid-button-panel-anim {
+    -webkit-animation-name: anim-panel-in;
+            animation-name: anim-panel-in;
+    -webkit-animation-duration: 2s;
+            animation-duration: 2s;
+    -webkit-animation-delay: 0s;
+            animation-delay: 0s; }
+    .spid-enter-container:not([hidden]) .spid-button-panel-anim .spid-button-fade-in-left {
+      -webkit-animation-name: spid-button-logo-left-fade-in;
+              animation-name: spid-button-logo-left-fade-in;
+      -webkit-animation-duration: 0.5s;
+              animation-duration: 0.5s;
+      -webkit-animation-delay: 0.5s;
+              animation-delay: 0.5s;
+      -webkit-animation-fill-mode: both;
+              animation-fill-mode: both; }
+    .spid-enter-container:not([hidden]) .spid-button-panel-anim .spid-button-fade-in-right {
+      -webkit-animation-name: spid-button-close-right-fade-in;
+              animation-name: spid-button-close-right-fade-in;
+      -webkit-animation-duration: 0.5s;
+              animation-duration: 0.5s;
+      -webkit-animation-delay: 1s;
+              animation-delay: 1s;
+      -webkit-animation-fill-mode: both;
+              animation-fill-mode: both; }
+    .spid-enter-container:not([hidden]) .spid-button-panel-anim .spid-button-fade-in-bottom {
+      -webkit-animation-name: spid-button-title-fade-in;
+              animation-name: spid-button-title-fade-in;
+      -webkit-animation-duration: 0.5s;
+              animation-duration: 0.5s;
+      -webkit-animation-delay: 0.5s;
+              animation-delay: 0.5s;
+      -webkit-animation-fill-mode: both;
+              animation-fill-mode: both; }
+
+.spid-button-idp-fade-in {
+  -webkit-animation-name: spid-button-anim-idp-fade-in;
+          animation-name: spid-button-anim-idp-fade-in;
+  -webkit-animation-duration: 0.5s;
+          animation-duration: 0.5s;
+  -webkit-animation-fill-mode: both;
+          animation-fill-mode: both; }
+
+@-webkit-keyframes spid-button-anim-idp-fade-in {
+  from {
+    opacity: 0; }
+  to {
+    opacity: 1; } }
+
+@keyframes spid-button-anim-idp-fade-in {
+  from {
+    opacity: 0; }
+  to {
+    opacity: 1; } }
+
+.spid-button-idp-fade-out {
+  -webkit-animation-name: spid-button-anim-idp-fade-out;
+          animation-name: spid-button-anim-idp-fade-out;
+  -webkit-animation-duration: 0.5s;
+          animation-duration: 0.5s;
+  -webkit-animation-fill-mode: both;
+          animation-fill-mode: both; }
+
+@-webkit-keyframes spid-button-anim-idp-fade-out {
+  from {
+    opacity: 1; }
+  to {
+    opacity: 0; } }
+
+@keyframes spid-button-anim-idp-fade-out {
+  from {
+    opacity: 1; }
+  to {
+    opacity: 0; } }
+
+@-webkit-keyframes spid-button-logo-left-fade-in {
+  from {
+    -webkit-transform: translate(-50px);
+            transform: translate(-50px); }
+  to {
+    -webkit-transform: none;
+            transform: none; } }
+
+@keyframes spid-button-logo-left-fade-in {
+  from {
+    -webkit-transform: translate(-50px);
+            transform: translate(-50px); }
+  to {
+    -webkit-transform: none;
+            transform: none; } }
+
+@-webkit-keyframes spid-button-close-right-fade-in {
+  from {
+    -webkit-transform: none;
+            transform: none; }
+  to {
+    -webkit-transform: translate(-50px);
+            transform: translate(-50px); } }
+
+@keyframes spid-button-close-right-fade-in {
+  from {
+    -webkit-transform: none;
+            transform: none; }
+  to {
+    -webkit-transform: translate(-50px);
+            transform: translate(-50px); } }
+
+@-webkit-keyframes spid-button-title-fade-in {
+  from {
+    opacity: 0;
+    -webkit-transform: translateY(200%);
+            transform: translateY(200%); }
+  to {
+    opacity: 1;
+    -webkit-transform: none;
+            transform: none; } }
+
+@keyframes spid-button-title-fade-in {
+  from {
+    opacity: 0;
+    -webkit-transform: translateY(200%);
+            transform: translateY(200%); }
+  to {
+    opacity: 1;
+    -webkit-transform: none;
+            transform: none; } }
+
+@-webkit-keyframes spid-button-logo-left-fade-out {
+  from {
+    -webkit-transform: none;
+            transform: none; }
+  to {
+    -webkit-transform: translate(-50px);
+            transform: translate(-50px); } }
+
+@keyframes spid-button-logo-left-fade-out {
+  from {
+    -webkit-transform: none;
+            transform: none; }
+  to {
+    -webkit-transform: translate(-50px);
+            transform: translate(-50px); } }
+
+@-webkit-keyframes spid-button-close-right-fade-out {
+  from {
+    -webkit-transform: none;
+            transform: none; }
+  to {
+    -webkit-transform: translate(-50px);
+            transform: translate(-50px); } }
+
+@keyframes spid-button-close-right-fade-out {
+  from {
+    -webkit-transform: none;
+            transform: none; }
+  to {
+    -webkit-transform: translate(-50px);
+            transform: translate(-50px); } }
+
+@-webkit-keyframes spid-button-title-fade-out {
+  from {
+    opacity: 0;
+    -webkit-transform: none;
+            transform: none; }
+  to {
+    opacity: 1;
+    -webkit-transform: translateY(200%);
+            transform: translateY(200%); } }
+
+@keyframes spid-button-title-fade-out {
+  from {
+    opacity: 0;
+    -webkit-transform: none;
+            transform: none; }
+  to {
+    opacity: 1;
+    -webkit-transform: translateY(200%);
+            transform: translateY(200%); } }
+
+@-webkit-keyframes anim-base-in {
+  0% {
+    width: 180px;
+    height: 48px;
+    top: calc((100vh - 48px) / 2);
+    left: calc((100vw - 180px) / 2);
+    border-radius: 100%;
+    opacity: 0; }
+  50% {
+    width: 180px;
+    height: 48px;
+    top: calc((100vh - 48px) / 2);
+    left: calc((100vw - 180px) / 2);
+    border-radius: 100%;
+    opacity: 1; }
+  100% {
+    top: calc((100vh - 48px) / 2);
+    left: calc((100vw - 180px) / 2);
+    -webkit-transform: scale(30);
+            transform: scale(30);
+    border-radius: 100%;
+    opacity: 1; } }
+
+@keyframes anim-base-in {
+  0% {
+    width: 180px;
+    height: 48px;
+    top: calc((100vh - 48px) / 2);
+    left: calc((100vw - 180px) / 2);
+    border-radius: 100%;
+    opacity: 0; }
+  50% {
+    width: 180px;
+    height: 48px;
+    top: calc((100vh - 48px) / 2);
+    left: calc((100vw - 180px) / 2);
+    border-radius: 100%;
+    opacity: 1; }
+  100% {
+    top: calc((100vh - 48px) / 2);
+    left: calc((100vw - 180px) / 2);
+    -webkit-transform: scale(30);
+            transform: scale(30);
+    border-radius: 100%;
+    opacity: 1; } }
+
+@-webkit-keyframes anim-base-out {
+  0% {
+    top: calc((100vh - 48px) / 2);
+    left: calc((100vw - 180px) / 2);
+    -webkit-transform: scale(30);
+            transform: scale(30);
+    border-radius: 100%;
+    opacity: 1; }
+  50% {
+    width: 180px;
+    height: 48px;
+    top: calc((100vh - 48px) / 2);
+    left: calc((100vw - 180px) / 2);
+    border-radius: 100%;
+    opacity: 0.5; }
+  100% {
+    width: 180px;
+    height: 48px;
+    top: calc((100vh - 48px) / 2);
+    left: calc((100vw - 180px) / 2);
+    border-radius: 100%;
+    opacity: 0; } }
+
+@keyframes anim-base-out {
+  0% {
+    top: calc((100vh - 48px) / 2);
+    left: calc((100vw - 180px) / 2);
+    -webkit-transform: scale(30);
+            transform: scale(30);
+    border-radius: 100%;
+    opacity: 1; }
+  50% {
+    width: 180px;
+    height: 48px;
+    top: calc((100vh - 48px) / 2);
+    left: calc((100vw - 180px) / 2);
+    border-radius: 100%;
+    opacity: 0.5; }
+  100% {
+    width: 180px;
+    height: 48px;
+    top: calc((100vh - 48px) / 2);
+    left: calc((100vw - 180px) / 2);
+    border-radius: 100%;
+    opacity: 0; } }
+
+@-webkit-keyframes anim-icon-in {
+  0% {
+    width: 30px;
+    height: 30px;
+    top: 50vh;
+    left: 50vw;
+    opacity: 0; }
+  5% {
+    width: 30px;
+    height: 30px;
+    top: 50vh;
+    left: 50vw;
+    opacity: 0.2; }
+  100% {
+    top: 0;
+    left: 20vw;
+    width: 120vw;
+    height: 120vh;
+    opacity: 0.1; } }
+
+@keyframes anim-icon-in {
+  0% {
+    width: 30px;
+    height: 30px;
+    top: 50vh;
+    left: 50vw;
+    opacity: 0; }
+  5% {
+    width: 30px;
+    height: 30px;
+    top: 50vh;
+    left: 50vw;
+    opacity: 0.2; }
+  100% {
+    top: 0;
+    left: 20vw;
+    width: 120vw;
+    height: 120vh;
+    opacity: 0.1; } }
+
+@-webkit-keyframes anim-icon-out {
+  0% {
+    top: 0;
+    left: 20vw;
+    width: 120vw;
+    height: 120vh;
+    opacity: 0.1; }
+  50% {
+    width: 30px;
+    height: 30px;
+    top: 50vh;
+    left: 50vw;
+    opacity: 0; }
+  100% {
+    width: 30px;
+    height: 30px;
+    top: 50vh;
+    left: 50vw;
+    opacity: 0; } }
+
+@keyframes anim-icon-out {
+  0% {
+    top: 0;
+    left: 20vw;
+    width: 120vw;
+    height: 120vh;
+    opacity: 0.1; }
+  50% {
+    width: 30px;
+    height: 30px;
+    top: 50vh;
+    left: 50vw;
+    opacity: 0; }
+  100% {
+    width: 30px;
+    height: 30px;
+    top: 50vh;
+    left: 50vw;
+    opacity: 0; } }
+
+@-webkit-keyframes anim-panel-in {
+  0% {
+    opacity: 0; }
+  15% {
+    opacity: 0; }
+  100% {
+    opacity: 1; } }
+
+@keyframes anim-panel-in {
+  0% {
+    opacity: 0; }
+  15% {
+    opacity: 0; }
+  100% {
+    opacity: 1; } }
+
+@-webkit-keyframes anim-panel-out {
+  0% {
+    opacity: 1; }
+  100% {
+    opacity: 0; } }
+
+@keyframes anim-panel-out {
+  0% {
+    opacity: 1; }
+  100% {
+    opacity: 0; } }
+
+@-webkit-keyframes hide-on-end {
+  0% {
+    height: 100vh; }
+  100% {
+    height: 0; } }
+
+@keyframes hide-on-end {
+  0% {
+    height: 100vh; }
+  100% {
+    height: 0; } }
+
+.spid-button.spid-button-transition {
+  -webkit-animation-name: fadeOutEnterBtn;
+          animation-name: fadeOutEnterBtn;
+  -webkit-animation-duration: 1s;
+          animation-duration: 1s;
+  -webkit-animation-fill-mode: forwards;
+          animation-fill-mode: forwards; }
+
+.spid-button.spid-button-reverse-enter-transition {
+  -webkit-animation-name: fadeInEnterBtn;
+          animation-name: fadeInEnterBtn;
+  -webkit-animation-duration: 1s;
+          animation-duration: 1s; }
+
+.spid-button-little-man-icon {
+  -webkit-animation-name: spid-show-little-man;
+          animation-name: spid-show-little-man;
+  -webkit-animation-duration: 1s;
+          animation-duration: 1s;
+  -webkit-animation-timing-function: ease;
+          animation-timing-function: ease;
+  -webkit-animation-fill-mode: forwards;
+          animation-fill-mode: forwards; }
+
+.spid-button-icon-animation {
+  -webkit-animation-name: spid-button-icon-smaller-logo;
+          animation-name: spid-button-icon-smaller-logo;
+  -webkit-animation-duration: 1s;
+          animation-duration: 1s;
+  -webkit-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-fill-mode: forwards;
+          animation-fill-mode: forwards; }
+
+.spid-button-icon-animation.in {
+  -webkit-animation-name: spid-button-icon-bigger-logo;
+          animation-name: spid-button-icon-bigger-logo;
+  -webkit-animation-duration: 1s;
+          animation-duration: 1s;
+  -webkit-animation-timing-function: linear;
+          animation-timing-function: linear;
+  -webkit-animation-fill-mode: forwards;
+          animation-fill-mode: forwards; }
+
+.spid-button-logo-animation-out {
+  -webkit-animation-name: spid-hide-little-man;
+          animation-name: spid-hide-little-man;
+  -webkit-animation-duration: 1s;
+          animation-duration: 1s;
+  -webkit-animation-timing-function: ease;
+          animation-timing-function: ease; }
+
+@-webkit-keyframes spid-show-little-man {
+  0% {
+    opacity: 0; }
+  100% {
+    opacity: 0.15;
+    position: absolute;
+    top: 80%;
+    left: 75%;
+    width: 15%; } }
+
+@keyframes spid-show-little-man {
+  0% {
+    opacity: 0; }
+  100% {
+    opacity: 0.15;
+    position: absolute;
+    top: 80%;
+    left: 75%;
+    width: 15%; } }
+
+@media (max-width: 1110px) {
+  @-webkit-keyframes spid-show-little-man {
+    100% {
+      opacity: 0.15;
+      position: absolute;
+      top: 77%;
+      left: 80%;
+      width: 12%; } }
+  @keyframes spid-show-little-man {
+    100% {
+      opacity: 0.15;
+      position: absolute;
+      top: 77%;
+      left: 80%;
+      width: 12%; } } }
+
+@-webkit-keyframes spid-hide-little-man {
+  50% {
+    opacity: 0; }
+  100% {
+    top: 0;
+    left: 0; } }
+
+@keyframes spid-hide-little-man {
+  50% {
+    opacity: 0; }
+  100% {
+    top: 0;
+    left: 0; } }
+
+@-webkit-keyframes fadeOutEnterBtn {
+  from {
+    outline: none;
+    opacity: 1; }
+  to {
+    outline: none;
+    opacity: 0.2; } }
+
+@keyframes fadeOutEnterBtn {
+  from {
+    outline: none;
+    opacity: 1; }
+  to {
+    outline: none;
+    opacity: 0.2; } }
+
+@-webkit-keyframes spid-button-icon-bigger-logo {
+  0% {
+    opacity: 1; }
+  99% {
+    opacity: 0.2; }
+  100% {
+    opacity: 0;
+    -webkit-transform-origin: top left;
+            transform-origin: top left;
+    -webkit-transform: translate(50vw, 50vh) scale(10);
+            transform: translate(50vw, 50vh) scale(10); } }
+
+@keyframes spid-button-icon-bigger-logo {
+  0% {
+    opacity: 1; }
+  99% {
+    opacity: 0.2; }
+  100% {
+    opacity: 0;
+    -webkit-transform-origin: top left;
+            transform-origin: top left;
+    -webkit-transform: translate(50vw, 50vh) scale(10);
+            transform: translate(50vw, 50vh) scale(10); } }
+
+@media screen and (max-width: 767px) {
+  @-webkit-keyframes spid-button-icon-bigger-logo {
+    from {
+      opacity: 1;
+      visibility: hidden; }
+    to {
+      opacity: 0.2;
+      -webkit-transform: translate(50vw, 50vh) scale(10);
+              transform: translate(50vw, 50vh) scale(10);
+      visibility: visible; } }
+  @keyframes spid-button-icon-bigger-logo {
+    from {
+      opacity: 1;
+      visibility: hidden; }
+    to {
+      opacity: 0.2;
+      -webkit-transform: translate(50vw, 50vh) scale(10);
+              transform: translate(50vw, 50vh) scale(10);
+      visibility: visible; } } }
+
+@-webkit-keyframes spid-button-icon-smaller-logo {
+  0% {
+    opacity: 0.2;
+    -webkit-transform-origin: top left;
+            transform-origin: top left;
+    -webkit-transform: translate(50vw, 50vh) scale(10);
+            transform: translate(50vw, 50vh) scale(10); }
+  100% {
+    -webkit-transform: none;
+            transform: none;
+    opacity: 1; } }
+
+@keyframes spid-button-icon-smaller-logo {
+  0% {
+    opacity: 0.2;
+    -webkit-transform-origin: top left;
+            transform-origin: top left;
+    -webkit-transform: translate(50vw, 50vh) scale(10);
+            transform: translate(50vw, 50vh) scale(10); }
+  100% {
+    -webkit-transform: none;
+            transform: none;
+    opacity: 1; } }
+
+@media screen and (max-width: 767px) {
+  @-webkit-keyframes spid-button-icon-smaller-logo {
+    from {
+      opacity: 0.2;
+      -webkit-transform: translate(50vw, 50vh) scale(10);
+              transform: translate(50vw, 50vh) scale(10); }
+    to {
+      -webkit-transform: none;
+              transform: none;
+      opacity: 1; } }
+  @keyframes spid-button-icon-smaller-logo {
+    from {
+      opacity: 0.2;
+      -webkit-transform: translate(50vw, 50vh) scale(10);
+              transform: translate(50vw, 50vh) scale(10); }
+    to {
+      -webkit-transform: none;
+              transform: none;
+      opacity: 1; } } }
+
+@-webkit-keyframes fadeInEnterBtn {
+  from {
+    opacity: 0.2; }
+  to {
+    opacity: 1; } }
+
+@keyframes fadeInEnterBtn {
+  from {
+    opacity: 0.2; }
+  to {
+    opacity: 1; } }

--- a/src/modalVariant/index.tsx
+++ b/src/modalVariant/index.tsx
@@ -6,7 +6,8 @@ import { getTranslationFn } from '../shared/i18n';
 import {
   computeButtonClasses,
   computeButtonTransitionClasses,
-  isVisible
+  isVisible,
+  getDefinedClasses
 } from './utils';
 
 import { DEFAULT_TRANSITION_TIME, ESC_KEY, possibleStates } from './constants';
@@ -20,6 +21,8 @@ import { ProvidersModal } from './ProvidersModal';
 import type { TranslateFn } from '../shared/i18n';
 import type { SPIDButtonProps } from '../shared/types';
 import type { ModalState } from './types';
+
+import styles from './index.module.css';
 
 const providersList = getShuffledProviders();
 
@@ -50,16 +53,24 @@ const LoginButton = ({
     theme === 'negative' ? SpidIcoCircleLbUrl : SpidIcoCircleBbUrl;
   return (
     <button
-      className={`spid-button ${customStylingClasses} ${wrapperTransitionClasses}`}
+      className={`${styles['spid-button']} ${getDefinedClasses(
+        customStylingClasses,
+        styles
+      )} ${getDefinedClasses(wrapperTransitionClasses, styles)}`}
       onClick={() => toggleModal(true)}
     >
       <span
         aria-hidden={!isVisible(modalVisibility)}
-        className={`spid-button-icon ${iconButtonClasses}`}
+        className={`${styles['spid-button-icon']} ${getDefinedClasses(
+          iconButtonClasses,
+          styles
+        )}`}
       >
         <img src={buttonImageUrl} alt={i18n('entra_con_SPID')} />
       </span>
-      <span className='spid-button-text'>{i18n('entra_con_SPID')}</span>
+      <span className={styles['spid-button-text']}>
+        {i18n('entra_con_SPID')}
+      </span>
     </button>
   );
 };

--- a/src/modalVariant/utils.test.tsx
+++ b/src/modalVariant/utils.test.tsx
@@ -4,13 +4,13 @@ import { computeButtonClasses, isVisible } from './utils';
 describe('Modal Utils', () => {
   describe('computeButtonClasses', () => {
     it('should fallback to large if `xl` is passed', () => {
-      expect(computeButtonClasses({ size: 'xl' })).toEqual(
+      expect(computeButtonClasses({ size: 'xl' })).toEqual([
         'spid-button-size-large'
-      );
+      ]);
     });
 
     it('should return no class for fluid falsy', () => {
-      expect(computeButtonClasses({ fluid: false })).toEqual('');
+      expect(computeButtonClasses({ fluid: false })).toEqual([]);
     });
   });
 

--- a/src/modalVariant/utils.tsx
+++ b/src/modalVariant/utils.tsx
@@ -15,7 +15,7 @@ export function computeButtonClasses({
   corners,
   size,
   fluid
-}: classesProps) {
+}: classesProps): string[] {
   if (process.env.NODE_ENV === 'production') {
     if (size === 'xl') {
       console.log(
@@ -30,31 +30,47 @@ export function computeButtonClasses({
     fluid ? 'fluid' : null
   ]
     .map((type) => (type != null ? `spid-button-${type}` : null))
-    .filter(Boolean)
-    .join(' ');
+    .filter<string>((name: string | null): name is string => name != null);
 }
 
-export function computeButtonTransitionClasses({ type }: ModalState) {
+const emptyClasses: string[] = [];
+export function computeButtonTransitionClasses({
+  type
+}: ModalState): { wrapper: string[]; icon: string[] } {
+  const inClass = 'in';
   switch (type) {
     case possibleStates.ENTERING.type:
       return {
-        wrapper: 'spid-button-transition',
-        icon: `${buttonIconAnimationClass} in`
+        wrapper: ['spid-button-transition'],
+        icon: [buttonIconAnimationClass, inClass]
       };
     case possibleStates.ENTERED.type:
-      return { wrapper: '', icon: `${buttonIconAnimationClass} in` };
+      return {
+        wrapper: emptyClasses,
+        icon: [buttonIconAnimationClass, inClass]
+      };
     case possibleStates.EXITING.type:
       return {
-        wrapper: 'spid-button-reverse-enter-transition',
-        icon: buttonIconAnimationClass
+        wrapper: ['spid-button-reverse-enter-transition'],
+        icon: [buttonIconAnimationClass]
       };
     case possibleStates.EXITED.type:
-      return { wrapper: '', icon: buttonIconAnimationClass };
+      return { wrapper: emptyClasses, icon: [buttonIconAnimationClass] };
     case possibleStates.INIT.type:
-      return { wrapper: '', icon: '' };
+      return { wrapper: emptyClasses, icon: emptyClasses };
   }
 }
 
 export function isVisible(modalState: ModalState) {
   return modalState.type.includes('enter');
+}
+
+export function getDefinedClasses(
+  klasses: string[],
+  styles: Record<string, string>
+) {
+  return klasses
+    ?.map((klass) => styles[klass])
+    .filter(Boolean)
+    .join(' ');
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -144,10 +144,12 @@ export type SPIDButtonProps = {
   /**
    * This is called when a user clicks on a provider button.
    * @param providerEntry The full entry of the provider clicked is passed, together with the event
+   * @param loginURL The final URL for the specific Identity Provider. It returns undefined if the button is disabled
    * @param event React original MouseEvent
    */
   onProviderClicked?: (
     providerEntry: ProviderRecord,
+    loginURL: string | undefined,
     event:
       | React.MouseEvent<HTMLAnchorElement, MouseEvent>
       | React.MouseEvent<HTMLButtonElement, MouseEvent>


### PR DESCRIPTION
Fixes: #5 

This PR drops the dependency on the `spid-smart-button` package, keeping it as dev dependency only.

It also introduces a new argument for the `onClickProvider` handler, the final URL computed with the mapping object. and it solves a bug about it for the dropdown version.