### PR TITLE
Enable newer version of React + fix transient peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "doc": "typedoc src/index.tsx --excludePrivate --json ./doc.json && node scripts/doc.js"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
+    "react": ">=16.0.0",
+    "react-dom": ">=16.0.0",
     "typeface-titillium-web": "latest"
   },
   "devDependencies": {


### PR DESCRIPTION
On 0.1.0 version I saw this on bundlephobia 😱  :

<img width="1164" alt="Screenshot 2021-04-08 at 09 06 07" src="https://user-images.githubusercontent.com/924948/113982955-abf61d80-9849-11eb-8157-df47e29dd13d.png">

The bundle is now considered 10x the actual size?!

Then looking into thee bundlephobia I found [this issue](https://github.com/pastelsky/bundlephobia/issues/494) which leads to this article about ["how peerdependencies work"](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0).

This PR forwards the `react-dom` peerDependency (and ignores the `prop-types` one for now).
Also it enables react 17 to work.