### PR TITLE
Reworked accessibility flow to support more browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ function Example(){
 
 **Note**: the providers list has no particular sorting order and is shuffled at every page load.
 
+
+#### Accessibility notes
+
+In general using the `POST` version of this component makes it usable for the most wide audience, as the `GET` version uses links which may have issues. To know more read below.
+
+The component tries its best to provide the best a11y practices implemented, but there are some specific browser behaviours that may still keep it hard to use with keyboard.
+In particular in OSX Safari and Firefox have some issues with `focus` and the behaviour of `tab`: [please read about it](https://github.com/theKashey/react-focus-lock#focusing-in-osx-safarifirefox-is-strange) when using this component.
+
+
 # API
 
 

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -1,3 +1,5 @@
+import 'react-app-polyfill/ie11';
+import 'react-app-polyfill/stable';
 import './index.css'
 
 import React from 'react'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dej611/spid-react-button",
-  "version": "0.0.3",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1215,7 +1215,6 @@
       "version": "7.13.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.7.tgz",
       "integrity": "sha512-h+ilqoX998mRVM5FtB5ijRuHUDVt5l3yfoOi2uh18Z/O3hvyaHQ39NpxVkCIG5yFs+mLq/ewFp8Bss6zmWv6ZA==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -3125,6 +3124,14 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-hidden": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.1.2.tgz",
+      "integrity": "sha512-WAMH9q3vRimVqP+B0q2eDvx7IPDoY17A2fWwj5atTA/zTYJCNcS6HJ5YErZ5FO3PUHhrV0y0yR1NA0dRNm913A==",
+      "requires": {
+        "tslib": "^1.0.0"
       }
     },
     "aria-query": {
@@ -6060,6 +6067,11 @@
       "integrity": "sha512-qi86tE6hRcFHy8jI1m2VG+LaPUR1LhqDa5G8tVjuUXmOrpuAgqsA1pN0+ldgr3aKUH+QLI9hCY/OcRYisERejw==",
       "dev": true
     },
+    "detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
     "detect-port-alt": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
@@ -7867,20 +7879,12 @@
         }
       }
     },
-    "focus-trap": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.3.0.tgz",
-      "integrity": "sha512-BBzvFfkPg5PqrVVCdQ1YOIVNKGvqG9YNVkiAUQFuDM66N8J9uADhs6mlYKrd30ofDJIzEniBnBKM7GO45iCzKQ==",
+    "focus-lock": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.8.1.tgz",
+      "integrity": "sha512-/LFZOIo82WDsyyv7h7oc0MJF9ACOvDRdx9rWPZ2pgMfNWu/z8hQDBtOchuB/0BVLmuFOZjV02YwUVzNsWx/EzA==",
       "requires": {
-        "tabbable": "^5.1.5"
-      }
-    },
-    "focus-trap-react": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-8.4.2.tgz",
-      "integrity": "sha512-yuItOIwgriOBMrbHDqbWMpQjGVs9SbtugYrT0vs0yPjHiPKja3NZ9dBMxDQrV1JhyojGK5d6j7ayqBS7Kcm9xQ==",
-      "requires": {
-        "focus-trap": "^6.3.0"
+        "tslib": "^1.9.3"
       }
     },
     "follow-redirects": {
@@ -8116,6 +8120,11 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
       }
+    },
+    "get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
     },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.2",
@@ -8994,7 +9003,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -10734,8 +10742,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -11139,7 +11146,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -12194,8 +12200,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -14222,7 +14227,6 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -14429,6 +14433,14 @@
         "raf": "^3.4.1",
         "regenerator-runtime": "^0.13.3",
         "whatwg-fetch": "^3.0.0"
+      }
+    },
+    "react-clientside-effect": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.5.tgz",
+      "integrity": "sha512-2bL8qFW1TGBHozGGbVeyvnggRpMjibeZM2536AKNENLECutp2yfs44IL8Hmpn8qjFQ2K7A9PnYf3vc7aQq/cPA==",
+      "requires": {
+        "@babel/runtime": "^7.12.13"
       }
     },
     "react-dev-utils": {
@@ -14664,11 +14676,57 @@
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
       "dev": true
     },
+    "react-focus-lock": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.5.0.tgz",
+      "integrity": "sha512-XLxj6uTXgz0US8TmqNU2jMfnXwZG0mH2r/afQqvPEaX6nyEll5LHVcEXk2XDUQ34RVeLPkO/xK5x6c/qiuSq/A==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^0.8.1",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.2",
+        "use-callback-ref": "^1.2.1",
+        "use-sidecar": "^1.0.1"
+      }
+    },
+    "react-focus-on": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.5.2.tgz",
+      "integrity": "sha512-tpPxLqw9tEuElWmcr5jqw/ULfJjdHEnom0nBW9p6y75Zsa0wOfwQNqCHqCoJcHUqSBtKXqTuYduZoSTfTOTdJw==",
+      "requires": {
+        "aria-hidden": "^1.1.2",
+        "react-focus-lock": "^2.5.0",
+        "react-remove-scroll": "^2.4.1",
+        "react-style-singleton": "^2.1.1",
+        "use-callback-ref": "^1.2.5",
+        "use-sidecar": "^1.0.5"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-remove-scroll": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.4.1.tgz",
+      "integrity": "sha512-K7XZySEzOHMTq7dDwcHsZA6Y7/1uX5RsWhRXVYv8rdh+y9Qz2nMwl9RX/Mwnj/j7JstCGmxyfyC0zbVGXYh3mA==",
+      "requires": {
+        "react-remove-scroll-bar": "^2.1.0",
+        "react-style-singleton": "^2.1.0",
+        "tslib": "^1.0.0",
+        "use-callback-ref": "^1.2.3",
+        "use-sidecar": "^1.0.1"
+      }
+    },
+    "react-remove-scroll-bar": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.2.0.tgz",
+      "integrity": "sha512-UU9ZBP1wdMR8qoUs7owiVcpaPwsQxUDC2lypP6mmixaGlARZa7ZIBx1jcuObLdhMOvCsnZcvetOho0wzPa9PYg==",
+      "requires": {
+        "react-style-singleton": "^2.1.0",
+        "tslib": "^1.0.0"
+      }
     },
     "react-scripts": {
       "version": "3.4.4",
@@ -15033,6 +15091,16 @@
         }
       }
     },
+    "react-style-singleton": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.1.1.tgz",
+      "integrity": "sha512-jNRp07Jza6CBqdRKNgGhT3u9umWvils1xsuMOjZlghBDH2MU0PL2WZor4PGYjXpnRCa9DQSlHMs/xnABWOwYbA==",
+      "requires": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^1.0.0"
+      }
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -15129,8 +15197,7 @@
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-      "dev": true
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -17179,11 +17246,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
-    "tabbable": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.1.6.tgz",
-      "integrity": "sha512-KSlGaSX9PbL7FHDTn2dB+zv61prkY8BeGioTsKfeN7dKhw5uz1S4U2iFaWMK4GR8oU+5OFBkFuxbMsaUxVVlrQ=="
-    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
@@ -17619,8 +17681,7 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tsutils": {
       "version": "3.20.0",
@@ -17956,6 +18017,20 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "use-callback-ref": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.5.tgz",
+      "integrity": "sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg=="
+    },
+    "use-sidecar": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.5.tgz",
+      "integrity": "sha512-k9jnrjYNwN6xYLj1iaGhonDghfvmeTmYjAiGvOr7clwKfPjMXJf4/HOr7oT5tJwYafgp2tG2l3eZEOfoELiMcA==",
+      "requires": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^1.9.3"
+      }
     },
     "util": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dej611/spid-react-button",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pulsante SSO per SPID in React",
   "author": "dej611",
   "license": "EUPL-1.2",
@@ -31,9 +31,17 @@
     "doc": "typedoc src/index.tsx --excludePrivate --json ./doc.json && node scripts/doc.js"
   },
   "peerDependencies": {
-    "react": ">=16.0.0",
-    "react-dom": ">=16.0.0",
+    "react": ">=16.8.0",
+    "@types/react": ">=16.8.0",
     "typeface-titillium-web": "latest"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
+    "typeface-titillium-web": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@testing-library/jest-dom": "5.11.9",
@@ -81,7 +89,7 @@
   },
   "homepage": "https://github.com/dej611/spid-react-button",
   "dependencies": {
-    "focus-trap-react": "^8.4.2"
+    "react-focus-on": "^3.5.2"
   },
   "keywords": [
     "spid",

--- a/scripts/readme.template
+++ b/scripts/readme.template
@@ -36,6 +36,38 @@ function Example(){
 
 **Note**: the providers list has no particular sorting order and is shuffled at every page load.
 
+#### Accessibility notes
+
+In general using the `POST` version of this component makes it usable for the most wide audience, as the `GET` version uses links which may have issues. To know more read below.
+
+The component tries its best to provide the best a11y practices implemented, but there are some specific browser behaviours that may still keep it hard to use with keyboard.
+In particular in OSX Safari and Firefox have some issues with `focus` and the behaviour of `tab`: [please read about it](https://github.com/theKashey/react-focus-lock#focusing-in-osx-safarifirefox-is-strange) when using this component.
+
+
+#### Contributing
+
+To get up and running with the development of the project you can follow these steps.
+
+To see the component in action, useful to test it manually after some changes, open a terminal window and type:
+
+```sh
+cd example
+npm start
+```
+
+This will start the `create-react-app` project and open a new browser tab with the example application in it.
+
+At this point it is possible to perform changes to the component/library, open a new terminal in the project folder and use this command when done with changes:
+```sh
+npm build
+```
+
+To run the test do:
+
+```sh
+npm test
+```
+
 # API
 
 {{api}}

--- a/src/dropdownVariant/index.tsx
+++ b/src/dropdownVariant/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import FocusTrap from 'focus-trap-react';
+import { FocusOn } from 'react-focus-on';
 
 import SpidIcoCircleBbUrl from '/../shared/svgs/spid-ico-circle-bb.svg';
 import SpidIcoCircleLbUrl from '/../shared/svgs/spid-ico-circle-lb.svg';
@@ -8,8 +8,7 @@ import { SPIDButtonProps } from '../shared/types';
 import {
   validateURL,
   getShuffledProviders,
-  mergeProviders,
-  useEscapeKey
+  mergeProviders
 } from '../shared/utils';
 
 import styles from './index.module.css';
@@ -44,12 +43,6 @@ export const SPIDReactButton = ({
 
   const i18n = getTranslationFn(lang);
 
-  useEscapeKey(
-    () => toggleDropdown(false),
-    () => Boolean(openDropdown),
-    [openDropdown]
-  );
-
   useEffect(() => {
     if (openDropdown && onProvidersShown) {
       onProvidersShown();
@@ -67,7 +60,11 @@ export const SPIDReactButton = ({
     theme === 'negative' ? SpidIcoCircleLbUrl : SpidIcoCircleBbUrl;
 
   return (
-    <FocusTrap active={openDropdown}>
+    <FocusOn
+      onClickOutside={() => toggleDropdown(false)}
+      onEscapeKey={() => toggleDropdown(false)}
+      enabled={openDropdown}
+    >
       <div className={styles.container}>
         <a
           href='#'
@@ -98,6 +95,6 @@ export const SPIDReactButton = ({
           />
         )}
       </div>
-    </FocusTrap>
+    </FocusOn>
   );
 };

--- a/src/modalVariant/ProvidersModal.tsx
+++ b/src/modalVariant/ProvidersModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import FocusTrap from 'focus-trap-react';
+import { FocusOn } from 'react-focus-on';
 
 import SpidLogoAnimationBlackUrl from '/../shared/svgs/spid-logo-animation-black.svg';
 import SpidLogoUrl from '/../shared/svgs/spid-logo.svg';
@@ -89,7 +89,11 @@ export const ProvidersModal = ({
   } = getModalClasses(visibility);
 
   return (
-    <FocusTrap active={isVisible(visibility)}>
+    <FocusOn
+      onClickOutside={closeModal}
+      onEscapeKey={closeModal}
+      enabled={isVisible(visibility)}
+    >
       <section
         className={getDefinedClasses(['spid-enter-container'])}
         hidden={!isVisible(visibility)}
@@ -240,6 +244,6 @@ export const ProvidersModal = ({
           </section>
         </div>
       </section>
-    </FocusTrap>
+    </FocusOn>
   );
 };

--- a/src/modalVariant/index.tsx
+++ b/src/modalVariant/index.tsx
@@ -14,8 +14,7 @@ import { DEFAULT_TRANSITION_TIME, possibleStates } from './constants';
 import {
   mergeProviders,
   validateURL,
-  getShuffledProviders,
-  useEscapeKey
+  getShuffledProviders
 } from '../shared/utils';
 import { ProvidersModal } from './ProvidersModal';
 
@@ -100,12 +99,6 @@ export const SPIDReactButton = ({
   onProviderClicked
 }: SPIDButtonProps) => {
   const [state, setState] = useState<ModalState>(possibleStates.INIT);
-
-  useEscapeKey(
-    () => setState(possibleStates.EXITING),
-    () => isVisible(state),
-    [state]
-  );
 
   useEffect(() => {
     if (state.type === possibleStates.ENTERING.type) {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -6,9 +6,6 @@ import {
   Protocols,
   RegisteredProviderRecord
 } from './types';
-import { useEffect } from 'react';
-
-export const ESC_KEY = 27;
 
 // avoid http/https confusion and centralize this URL
 export const SPID_URL = 'https://www.spid.gov.it';
@@ -74,22 +71,4 @@ export function isProviderActive(
     (extraProviders.length === 0 || isExtraProviders) &&
     idp.active
   );
-}
-
-export function useEscapeKey(
-  changeState: () => void,
-  checkVisibility: () => boolean,
-  deps: unknown[]
-) {
-  useEffect(() => {
-    const escHandler = (event: KeyboardEvent) => {
-      if (event.keyCode === ESC_KEY) {
-        changeState();
-      }
-    };
-    if (checkVisibility()) {
-      document.addEventListener('keyup', escHandler);
-    }
-    return () => document.removeEventListener('keyup', escHandler);
-  }, deps);
 }


### PR DESCRIPTION
Fixes #44 

Previous implementation has some issues in the dropdown version of the button with OSX Firefox, where `tab` didn't loop on the providers once reached the bottom.

Issue:

![dropdown-ff-issue](https://user-images.githubusercontent.com/924948/114165300-9574c280-992c-11eb-8ea9-bdae00fbf878.gif)

Fixed:

![dropdown-ff-fix](https://user-images.githubusercontent.com/924948/114165320-9b6aa380-992c-11eb-843b-681149f9ceea.gif)

Also, this new library seems to be relying on more up-to-date dependencies.

Also, there are now more accessibility notes in the readme to point users to some references.
Took the opportunity to add also:
* :wrench: Add IE11 support to the example app
* ♻️ Replaced dependencies
* :boom: Raised min peer depedency version of React to 16.8 and above
* :wrench:  Made titilium font optional peer dep ( fixes #27 )
* :memo: Add contributing guidelines