### PR TITLE
New sorted feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 build
 dist
 .rpt2_cache
+coverage
 
 # misc
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -255,6 +255,21 @@ The default value is `"md"`.
 
 
 
+#### sorted
+
+
+**Type**: `boolean`  
+
+**Required**: No  
+
+**Default value**: false
+
+
+It forces an ascending order (A->Z) of the providers, based on the entityName string.  
+Note that this will sort with no distictions between official and extraProviders in the list.
+
+
+
 #### supported
 
 **Possible values**: `string[]`  

--- a/example/src/Configurator.tsx
+++ b/example/src/Configurator.tsx
@@ -169,6 +169,7 @@ export const Configurator = ({ buttonProps, updateProp, setValidURL, isValidURL 
       </Col>
     </div>
     <Row>
+      <Col md={6}>
       <fieldset>
         <legend>Provider supported:</legend>
         <FormGroup check>
@@ -189,6 +190,19 @@ export const Configurator = ({ buttonProps, updateProp, setValidURL, isValidURL 
           )}
         </FormGroup>
       </fieldset>
+      </Col>
+      <Col>
+        <FormGroup check>
+          <Toggle
+            label='Providers sorted'
+            checked={buttonProps.sorted}
+            onChange={({ target }) => {
+              // @ts-expect-error
+              updateProp('sorted', target.checked)
+            }}
+          />
+        </FormGroup>
+      </Col>
     </Row>
   </>
 }

--- a/example/src/constants.ts
+++ b/example/src/constants.ts
@@ -3,7 +3,7 @@ import { getShuffledProviders } from "@dej611/spid-react-button";
 import {Protocols, Languages, Sizes, CornerType, ColorTheme, ConfigurationGET, ConfigurationPOST, Types, SPIDButtonProps} from '@dej611/spid-react-button'
 
 export const defaultURL = "/myLogin/idp={{idp}}";
-export const providersList = getShuffledProviders();
+export const providersList = [...getShuffledProviders()].sort((idpA, idpB) => idpA.entityName.localeCompare(idpB.entityName));
 export const languages: Languages[] = ['it', 'en', 'de']
 export const configurations: [ConfigurationGET, ConfigurationPOST] = [{ method: 'GET' }, { method: 'POST', fieldName: 'prova' }]
 export const protocols: Protocols[] = ['SAML', 'OIDC']
@@ -27,5 +27,6 @@ export const initState: NoFunctionProps = {
     corners: cornerTypes[0],
     configuration: configurations[0],
     extraProviders: [],
-    type: types[0]
+    type: types[0],
+    sorted: false
   }

--- a/src/dropdownVariant/index.tsx
+++ b/src/dropdownVariant/index.tsx
@@ -32,6 +32,7 @@ export const SPIDReactButton = ({
   configuration = { method: 'GET' },
   theme = 'positive',
   protocol = 'SAML',
+  sorted = false,
   extraProviders = [],
   onProviderClicked,
   onProvidersHidden,
@@ -54,7 +55,9 @@ export const SPIDReactButton = ({
 
   validateURL(url);
 
-  const mergedProviders = mergeProviders(shuffledProviders, extraProviders);
+  const mergedProviders = mergeProviders(shuffledProviders, extraProviders, {
+    sorted
+  });
 
   const buttonImageUrl =
     theme === 'negative' ? SpidIcoCircleLbUrl : SpidIcoCircleBbUrl;

--- a/src/modalVariant/index.tsx
+++ b/src/modalVariant/index.tsx
@@ -93,6 +93,7 @@ export const SPIDReactButton = ({
   mapping = {},
   protocol = 'SAML',
   url,
+  sorted = false,
   supported = providersList.map(({ entityID }) => entityID),
   onProvidersShown,
   onProvidersHidden,
@@ -155,7 +156,9 @@ export const SPIDReactButton = ({
     onProviderClicked
   };
 
-  const mergedProviders = mergeProviders(providersList, extraProviders);
+  const mergedProviders = mergeProviders(providersList, extraProviders, {
+    sorted
+  });
 
   return (
     <div aria-live='polite'>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -93,6 +93,12 @@ export type SPIDButtonProps = {
    */
   supported?: ProviderRecord['entityID'][];
   /**
+   * It forces an ascending order (A->Z) of the providers, based on the entityName string.
+   * Note that this will sort with no distictions between official and extraProviders in the list.
+   * @defaultValue false
+   */
+  sorted?: boolean;
+  /**
    * The protocol to use for the current instance.
    * Only Providers who support the declared protocol are enabled.
    * The default value is `"SAML"`.

--- a/src/shared/utils.test.tsx
+++ b/src/shared/utils.test.tsx
@@ -106,5 +106,29 @@ describe('Shared utils', () => {
         expect(active).toEqual(false);
       }
     });
+
+    it('should sort providers by name when requested', () => {
+      const officialIdps: RegisteredProviderRecord[] = [
+        {
+          entityID: 'a',
+          entityName: 'A',
+          protocols: ['OIDC'],
+          active: true
+        },
+        {
+          entityID: 'c',
+          entityName: 'C',
+          protocols: ['OIDC'],
+          active: true
+        }
+      ];
+      const extraIdps: ProviderRecord[] = [{ entityID: 'b', entityName: 'B' }];
+      const merged = mergeProviders(officialIdps, extraIdps, { sorted: true });
+      expect(merged.map(({ entityName }) => entityName)).toEqual([
+        'A',
+        'B',
+        'C'
+      ]);
+    });
   });
 });

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -12,9 +12,10 @@ export const SPID_URL = 'https://www.spid.gov.it';
 
 export function mergeProviders(
   providers: Readonly<RegisteredProviderRecord>[],
-  extraProviders: ProviderRecord[]
+  extraProviders: ProviderRecord[],
+  { sorted }: { sorted?: boolean } = {}
 ): RegisteredProviderRecord[] {
-  return [
+  const mergedList = [
     ...providers.map((idp) => ({
       ...idp,
       active: !extraProviders.length
@@ -25,6 +26,12 @@ export function mergeProviders(
       active: true
     }))
   ];
+  if (!sorted) {
+    return mergedList;
+  }
+  return mergedList.sort((idpA, idpB) =>
+    idpA.entityName.localeCompare(idpB.entityName)
+  );
 }
 
 export function validateURL(url: string | undefined) {


### PR DESCRIPTION
Fixed #47 

New `sorted` prop in the `SPIDButtonProps` type, which forces an ascending sorting for idp providers (based on `entityName` strings).

Adds code to sort, unit tests and example handle to manually check.