### PR TITLE
Disable scroll lock for dropdown version

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -18,6 +18,6 @@ jobs:
             uses: actions/checkout@v2
             
           - name: Run FOSSA scan and upload build data
-            uses: fossa-contrib/fossa-action@v1.1.4
+            uses: fossa-contrib/fossa-action@e015db70fcadbf6316ed25b4c0c264d78d971714
             with:
               fossa-api-key: cdee9889737a795723195b4b4f9494cf

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -18,6 +18,6 @@ jobs:
             uses: actions/checkout@v2
             
           - name: Run FOSSA scan and upload build data
-            uses: fossa-contrib/fossa-action@v1
+            uses: fossa-contrib/fossa-action@v1.1.4
             with:
               fossa-api-key: cdee9889737a795723195b4b4f9494cf

--- a/src/dropdownVariant/index.tsx
+++ b/src/dropdownVariant/index.tsx
@@ -66,6 +66,7 @@ export const SPIDReactButton = ({
     <FocusOn
       onClickOutside={() => toggleDropdown(false)}
       onEscapeKey={() => toggleDropdown(false)}
+      scrollLock={false}
       enabled={openDropdown}
     >
       <div className={styles.container}>


### PR DESCRIPTION
Fixes #87 

This fix should disable the scroll lock on the page, whilee mantaining all the other a11y criteria for the dropdown.